### PR TITLE
Update wordpress-multi-server.yaml

### DIFF
--- a/wordpress-multi-server.yaml
+++ b/wordpress-multi-server.yaml
@@ -143,7 +143,7 @@ parameters:
         selected to deploy into.
 
   wp_master_server_flavor:
-    label: Server Size
+    label: Master Server Size
     description: |
       Cloud Server size to use for the web-master node. The size should be at
       least one size larger than what you use for the web nodes. This server
@@ -170,7 +170,7 @@ parameters:
         selected to deploy into.
 
   wp_web_server_flavor:
-    label: Server size
+    label: Node Server size
     description: |
       Cloud Server size to use on all of the additional web nodes.
     type: string


### PR DESCRIPTION
Changed the label for wp_master_server_flavor from Server Size to Master Server Size and wp_web_server_flavor to Node Server Size because it was confusing in Reach. Both showed Server Size as labels and it was hard to tell which server you were changing the size of.
