### PR TITLE
install v4.2.2

### DIFF
--- a/wordpress-multi-server.yaml
+++ b/wordpress-multi-server.yaml
@@ -207,10 +207,10 @@ parameters:
     label: WordPress Version
     description: Version of WordPress to install
     type: string
-    default: "4.2.1"
+    default: "4.2.2"
     constraints:
     - allowed_values:
-      - "4.2.1"
+      - "4.2.2"
 
   # Optional Apache settings (SSL certs)
   # ssl_private_key:


### PR DESCRIPTION
"WordPress 4.2.2 is now available. This is a critical security release
for all previous versions and we strongly encourage you to update your
sites immediately." https://wordpress.org/news/2015/05/wordpress-4-2-2/